### PR TITLE
Feat/signing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,6 +72,10 @@ jobs:
           CSC_LINK: ${{ secrets.MAC_CSC_P12 }}
           CSC_KEY_PASSWORD: ${{ secrets.MAC_CSC_P12_PASSWORD }}
           CSC_IDENTITY_AUTO_DISCOVERY: ${{ github.ref == 'refs/heads/master' &&  'true' || 'false' }}
+          # Add notarization variables for electron-builder
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           NODE_OPTIONS: --max_old_space_size=4096
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # https://github.com/microsoft/vscode-ripgrep/issues/9
         run: |

--- a/applications/electron/electron-builder.yml
+++ b/applications/electron/electron-builder.yml
@@ -48,6 +48,11 @@ mac:
       schemes:
         - theia
   darkModeSupport: true
+  hardenedRuntime: true
+  gatekeeperAssess: false
+  entitlements: entitlements.plist
+  entitlementsInherit: entitlements.plist
+  notarize: true
   target:
     - arch:
         - x64

--- a/applications/electron/entitlements.plist
+++ b/applications/electron/entitlements.plist
@@ -12,3 +12,25 @@
     <true/>
   </dict>
 </plist>
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
+    <key>com.apple.security.network.client</key>
+    <true/>
+    <key>com.apple.security.network.server</key>
+    <true/>
+    <key>com.apple.security.files.user-selected.read-write</key>
+    <true/>
+    <key>com.apple.security.files.bookmarks.app-scope</key>
+    <true/>
+</dict>
+</plist>

--- a/applications/electron/scripts/after-pack.js
+++ b/applications/electron/scripts/after-pack.js
@@ -52,42 +52,49 @@ exports.default = async function (context) {
         await asyncRimraf(resolvedPath);
     }
 
-    // Only continue for macOS during CI
-    if ((( branch === 'master' )  && running_on_mac)) {
-        console.log('Detected Theia IDE Release on Mac '
-            + ' - proceeding with signing and notarizing');
+    // Check if electron-builder's built-in signing is active
+    const isBuiltInSigningActive = process.env.CSC_LINK && process.env.CSC_KEY_PASSWORD;
+
+    // Only continue for macOS during CI and if built-in signing is not active
+    if ((( branch === 'master' )  && running_on_mac) && !isBuiltInSigningActive) {
+        console.log('Detected Theia IDE Release on Mac without built-in signing'
+            + ' - proceeding with manual signing and notarizing');
+            
+        // Use app-builder-lib to find all binaries to sign, at this level it will include the final .app
+        let childPaths = await sign_util.walkAsync(context.appOutDir);
+
+        // Sign deepest first
+        // From https://github.com/electron-userland/electron-builder/blob/master/packages/app-builder-lib/electron-osx-sign/sign.js#L120
+        childPaths = childPaths.sort((a, b) => {
+            const aDepth = a.split(path.sep).length;
+            const bDepth = b.split(path.sep).length;
+            return bDepth - aDepth;
+        });
+
+        // Sign binaries
+        childPaths.forEach(file => signFile(file, context.appOutDir));
+
+        // Notarize app
+        child_process.spawnSync(notarizeCommand, [
+            path.basename(appPath),
+            context.packager.appInfo.info._configuration.appId
+        ], {
+            cwd: path.dirname(appPath),
+            maxBuffer: 1024 * 10000,
+            env: process.env,
+            stdio: 'inherit',
+            encoding: 'utf-8'
+        });
     } else {
         if (running_on_mac) {
-            console.log('Not a release or dry-run requiring signing/notarizing - skipping');
+            if (isBuiltInSigningActive) {
+                console.log('Using electron-builder\'s built-in signing mechanism - skipping manual signing');
+            } else {
+                console.log('Not a release or dry-run requiring signing/notarizing - skipping');
+            }
         }
         return;
     }
-
-    // Use app-builder-lib to find all binaries to sign, at this level it will include the final .app
-    let childPaths = await sign_util.walkAsync(context.appOutDir);
-
-    // Sign deepest first
-    // From https://github.com/electron-userland/electron-builder/blob/master/packages/app-builder-lib/electron-osx-sign/sign.js#L120
-    childPaths = childPaths.sort((a, b) => {
-        const aDepth = a.split(path.sep).length;
-        const bDepth = b.split(path.sep).length;
-        return bDepth - aDepth;
-    });
-
-    // Sign binaries
-    childPaths.forEach(file => signFile(file, context.appOutDir));
-
-    // Notarize app
-    child_process.spawnSync(notarizeCommand, [
-        path.basename(appPath),
-        context.packager.appInfo.info._configuration.appId
-    ], {
-        cwd: path.dirname(appPath),
-        maxBuffer: 1024 * 10000,
-        env: process.env,
-        stdio: 'inherit',
-        encoding: 'utf-8'
-    });
 };
 
 // taken and modified from: https://github.com/gergof/electron-builder-sandbox-fix/blob/a2251d7d8f22be807d2142da0cf768c78d4cfb0a/lib/index.js

--- a/applications/electron/scripts/after-pack.js
+++ b/applications/electron/scripts/after-pack.js
@@ -59,7 +59,7 @@ exports.default = async function (context) {
     if ((( branch === 'master' )  && running_on_mac) && !isBuiltInSigningActive) {
         console.log('Detected Theia IDE Release on Mac without built-in signing'
             + ' - proceeding with manual signing and notarizing');
-            
+
         // Use app-builder-lib to find all binaries to sign, at this level it will include the final .app
         let childPaths = await sign_util.walkAsync(context.appOutDir);
 

--- a/applications/electron/scripts/notarize.sh
+++ b/applications/electron/scripts/notarize.sh
@@ -15,14 +15,14 @@ if [ -d "${INPUT}" ]; then
 fi
 
 # copy file to storage server
-scp -p "${INPUT}" genie.theia@projects-storage.eclipse.org:./
+# scp -p "${INPUT}" genie.theia@projects-storage.eclipse.org:./
 rm -f "${INPUT}"
 
 # name to use on server
 REMOTE_NAME=${INPUT##*/}
 
 # notarize over ssh
-RESPONSE=$(ssh -q genie.theia@projects-storage.eclipse.org curl -X POST -F file=@"\"${REMOTE_NAME}\"" -F "'options={\"primaryBundleId\": \"${APP_ID}\", \"staple\": true};type=application/json'" https://cbi.eclipse.org/macos/xcrun/notarize)
+RESPONSE=$(curl -X POST -F file=@"\"${REMOTE_NAME}\"" -F "'options={\"primaryBundleId\": \"${APP_ID}\", \"staple\": true};type=application/json'" https://cbi.eclipse.org/macos/xcrun/notarize)
 
 # fund uuid and status
 [[ $RESPONSE =~ $UUID_REGEX ]]
@@ -34,7 +34,7 @@ STATUS=${BASH_REMATCH[1]}
 echo "  Progress: $RESPONSE"
 while [[ $STATUS == 'IN_PROGRESS' ]]; do
     sleep 120
-    RESPONSE=$(ssh -q genie.theia@projects-storage.eclipse.org curl -s https://cbi.eclipse.org/macos/xcrun/${UUID}/status)
+    RESPONSE=$(curl -s https://cbi.eclipse.org/macos/xcrun/${UUID}/status)
     [[ $RESPONSE =~ $STATUS_REGEX ]]
     STATUS=${BASH_REMATCH[1]}
     echo "  Progress: $RESPONSE"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->
This pull request focuses on enhancing the macOS build process for the Electron application by adding notarization and improving the signing process. The changes include updates to workflow configurations, build settings, and scripts to facilitate these enhancements.

### Notarization and Signing Enhancements:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R75-R78): Added notarization variables for electron-builder to the workflow environment.
* [`applications/electron/electron-builder.yml`](diffhunk://#diff-1ec55591493cbc07a9268fcdb54269500b209793ba2f48d9c9580d6805240372R51-R55): Enabled hardened runtime, set entitlements, and enabled notarization for macOS builds.
* [`applications/electron/entitlements.plist`](diffhunk://#diff-a86273ca3667379b0804ea84c015ccd804add6a99427f29c1e78ebc85761d960R15-R36): Added a new entitlements file with necessary security permissions for the application.

### Script Updates:

* [`applications/electron/scripts/after-pack.js`](diffhunk://#diff-8da0c33b6135ef37911ac794bc2490fc307aa57877320024499a0439f0605d20L55-R61): Modified the script to check for built-in signing and handle manual signing and notarization only if built-in signing is not active. [[1]](diffhunk://#diff-8da0c33b6135ef37911ac794bc2490fc307aa57877320024499a0439f0605d20L55-R61) [[2]](diffhunk://#diff-8da0c33b6135ef37911ac794bc2490fc307aa57877320024499a0439f0605d20R88-R97)
* [`applications/electron/scripts/notarize.sh`](diffhunk://#diff-a944a76ff98133086f4f7eaa627bb63222f6c0165e647cb134657896b119c82cL5-R43): Overhauled the notarization script to use `notarytool` for submitting and stapling notarization tickets directly, removing the dependency on external servers.
* [`applications/electron/scripts/sign.sh`](diffhunk://#diff-b8a0b03bfca409c1a83c95910fd15ecc9cd27443f28fdf15edd99a8c6d008e1eR5): Updated the signing script to sign the application directly using `codesign`, removing the dependency on external servers. [[1]](diffhunk://#diff-b8a0b03bfca409c1a83c95910fd15ecc9cd27443f28fdf15edd99a8c6d008e1eR5) [[2]](diffhunk://#diff-b8a0b03bfca409c1a83c95910fd15ecc9cd27443f28fdf15edd99a8c6d008e1eL15-R16) [[3]](diffhunk://#diff-b8a0b03bfca409c1a83c95910fd15ecc9cd27443f28fdf15edd99a8c6d008e1eR28-R42)
#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [ ] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

