### PR TITLE
build: Configure macOS notarization with team ID from environment

### DIFF
--- a/applications/electron/electron-builder.yml
+++ b/applications/electron/electron-builder.yml
@@ -52,7 +52,8 @@ mac:
   gatekeeperAssess: false
   entitlements: entitlements.plist
   entitlementsInherit: entitlements.plist
-  notarize: true
+  notarize:
+    teamId: ${env.APPLE_TEAM_ID}
   target:
     - arch:
         - x64


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->
This pull request includes an important change to the `applications/electron/electron-builder.yml` file. The change modifies the notarization configuration for macOS builds.

Configuration updates:

* [`applications/electron/electron-builder.yml`](diffhunk://#diff-1ec55591493cbc07a9268fcdb54269500b209793ba2f48d9c9580d6805240372L55-R56): Updated the `notarize` configuration to include a `teamId` parameter, which is set using the `APPLE_TEAM_ID` environment variable.
#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [ ] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

